### PR TITLE
Add CCI's new checked headers to the checkedc-clang tests.

### DIFF
--- a/clang/test/CheckedC/headers/nostdinc.c
+++ b/clang/test/CheckedC/headers/nostdinc.c
@@ -15,6 +15,7 @@
 
 #if __has_include (<assert.h>) \
  || __has_include (<errno.h>) \
+ || __has_include (<fcntl.h>) \
  || __has_include (<fenv.h>) \
  || __has_include (<inttypes.h>) \
  || __has_include (<math.h>) \
@@ -22,18 +23,26 @@
  || __has_include (<stdio.h>) \
  || __has_include (<stdlib.h>) \
  || __has_include (<string.h>) \
+ || __has_include (<sys/stat.h>) \
  || __has_include (<threads.h>) \
  || __has_include (<time.h>) \
  || __has_include (<checkedc_extensions.h>) \
- || __has_include (<unistd.h>) \
+ || __has_include (<arpa/inet.h>) \
+ || __has_include (<grp.h>) \
+ || __has_include (<netdb.h>) \
+ || __has_include (<poll.h>) \
+ || __has_include (<pwd.h>) \
  || __has_include (<sys/socket.h>) \
- || __has_include (<arpa/inet.h>)
+ || __has_include (<syslog.h>) \
+ || __has_include (<unistd.h>) \
+ || __has_include (<utime.h>)
 #error "expected to *not* be able to find standard C headers"
 #endif
 
 
 #if __has_include (<assert_checked.h>) \
  || __has_include (<errno_checked.h>) \
+ || __has_include (<fcntl_checked.h>) \
  || __has_include (<fenv_checked.h>) \
  || __has_include (<inttypes_checked.h>) \
  || __has_include (<math_checked.h>) \
@@ -41,12 +50,19 @@
  || __has_include (<stdio_checked.h>) \
  || __has_include (<stdlib_checked.h>) \
  || __has_include (<string_checked.h>) \
+ || __has_include (<sys/stat_checked.h>) \
  || __has_include (<threads_checked.h>) \
  || __has_include (<time_checked.h>) \
  || __has_include (<checkedc_extensions.h>) \
- || __has_include (<unistd_checked.h>) \
+ || __has_include (<arpa/inet_checked.h>) \
+ || __has_include (<grp_checked.h>) \
+ || __has_include (<netdb_checked.h>) \
+ || __has_include (<poll_checked.h>) \
+ || __has_include (<pwd_checked.h>) \
  || __has_include (<sys/socket_checked.h>) \
- || __has_include (<arpa/inet_checked.h>)
+ || __has_include (<syslog_checked.h>) \
+ || __has_include (<unistd_checked.h>) \
+ || __has_include (<utime_checked.h>)
 #error "expected to *not* be able to find Checked C headers"
 #endif
 

--- a/clang/test/CheckedC/headers/nostdlibinc_explicit.c
+++ b/clang/test/CheckedC/headers/nostdlibinc_explicit.c
@@ -20,6 +20,8 @@
 // CHECK: assert.h
 #include <errno_checked.h>
 // CHECK: errno.h
+#include <fcntl_checked.h>
+// CHECK: fcntl.h
 #include <fenv_checked.h>
 // CHECK: fenv.h
 #include <inttypes_checked.h>
@@ -34,12 +36,13 @@
 // CHECK: stdlib.h
 #include <string_checked.h>
 // CHECK: string.h
+#include <sys/stat_checked.h>
+// CHECK: stat.h
 #include <time_checked.h>
 // CHECK: time.h
-//
-//
-// The following four files: threads.h unistd.h sys/socket.h arpa/inet.h
-// cannot be added here in this test case because a #if __has_include_next
-// guard is already present in each of these files to account for the
-// potential absence of the corresponding system header file.
+
+// Wrapper header files for system header files that don't exist on Windows
+// cannot be added here because they test for the system header via
+// __has_include_next and generate an `#error` instead of a -MG entry for the
+// system header.
 

--- a/clang/test/CheckedC/headers/nostdlibinc_implicit.c
+++ b/clang/test/CheckedC/headers/nostdlibinc_implicit.c
@@ -26,6 +26,10 @@
 #include <errno.h>
 #endif
 // CHECK: errno.h
+#if __has_include (<fcntl.h>)
+#include <fcntl.h>
+#endif
+// CHECK: fcntl.h
 #if __has_include (<fenv.h>)
 #include <fenv.h>
 #endif
@@ -54,14 +58,18 @@
 #include <string.h>
 #endif
 // CHECK: string.h
+#if __has_include (<sys/stat.h>)
+#include <sys/stat.h>
+#endif
+// CHECK: stat.h
 #if __has_include (<time.h>)
 #include <time.h>
 #endif
 // CHECK: time.h
 
-// The following four files: threads.h unistd.h sys/socket.h arpa/inet.h
-// cannot be added here in this test case because a #if __has_include_next
-// guard is already present in each of these files to account for the
-// potential absence of the corresponding system header file.
+// Wrapper header files for system header files that don't exist on Windows
+// cannot be added here because they test for the system header via
+// __has_include_next and generate an `#error` instead of a -MG entry for the
+// system header.
 
 #endif


### PR DESCRIPTION
This goes with microsoft/checkedc#448.  I believe it depends on microsoft/checkedc#448 but not vice versa, so it should be merged after microsoft/checkedc#448 in order to keep the tests passing.

I assumed you'd want this to be a separate PR from the 3C omnibus PR (draft coming soon).